### PR TITLE
Added stationary and flowing liquid blocks

### DIFF
--- a/Minecraft.Client/Blocks/Lava.cs
+++ b/Minecraft.Client/Blocks/Lava.cs
@@ -4,4 +4,14 @@
     {
         public Lava() : base(BlockType.Lava) { }
     }
+
+    public class LavaStationary : Block
+    {
+        public LavaStationary() : base(BlockType.LavaStationary) { }
+    }
+
+    public class LavaFlowing : Block
+    {
+        public LavaFlowing() : base(BlockType.LavaFlowing) { }
+    }
 }

--- a/Minecraft.Client/Blocks/Water.cs
+++ b/Minecraft.Client/Blocks/Water.cs
@@ -4,4 +4,9 @@
     {
         public Water() : base(BlockType.Water) { }
     }
+
+    public class WaterStationary : Block
+    {
+        public WaterStationary() : base(BlockType.WaterStationary) { }
+    }
 }

--- a/Minecraft.Client/JavaBlock.cs
+++ b/Minecraft.Client/JavaBlock.cs
@@ -90,6 +90,8 @@ namespace Decent.Minecraft.Client
             _ctors[(int)BlockType.Grass] = d => new Grass();
             _ctors[(int)BlockType.Iron] = d => new Iron();
             _ctors[(int)BlockType.IronOre] = d => new IronOre();
+            _ctors[(int)BlockType.LavaFlowing] = d => new LavaFlowing();
+            _ctors[(int)BlockType.LavaStationary] = d => new LavaStationary();
             _ctors[(int)BlockType.MossStone] = d => new MossStone();
             _ctors[(int)BlockType.Obsidian] = d => new Obsidian();
             _ctors[(int)BlockType.SnowLayer] = d => new SnowLayer();
@@ -99,6 +101,7 @@ namespace Decent.Minecraft.Client
                 d == 1 ? new MossyStoneBricks() :
                 d == 2 ? new CrackedStoneBricks() :
                 (Block)new ChiseledStoneBricks();
+            _ctors[(int)BlockType.WaterStationary] = d => new WaterStationary();
             _ctors[(int)BlockType.Wood] = d => new Wood((Wood.Species)(d & 0x3), (Orientation)(d & 0xC));
         }
 


### PR DESCRIPTION
Added definitions for Water Stationary, Lava Stationary, and Lava Flowing.  Also added deserialization.  Only added blocks and deserailization that I could detect successfully in the game client.  Previous commits allowed scripters to create Lava and Water blocks, and those were detectable in the data, but they were deserializing to UnknownBlock due to my omission in the earlier PR.

I added these as new blocks because I didn't see value in inheritance here.  When I have been testing creation, I have simply created new Lava() and new Water() and the game engine applies the rules of the game to begin flowing and shaping the rivers of liquid.  It seemed to do nothing different if I created new WaterStationary(), for example.

For deserialization, I found that the game wasn't detecting the player being on or near Water or Lava, but rather LavaFlowing, LavaStationary, or WaterStationary.  To this point I have not detected WaterFlowing, but working on that, so I kept it out of the PR.

Let's talk about this... I have been playing with this to determine the game's mechanics for this and determine what we want to expose to scripters.  