### PR TITLE
Adding some static blocks and gamepedia links.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 *.lock.json
 .vscode
 *.GhostDoc.xml
+.idea

--- a/Decent.Minecraft.Client/Blocks/Air.cs
+++ b/Decent.Minecraft.Client/Blocks/Air.cs
@@ -1,5 +1,10 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// Air is the block present in otherwise empty space.<br />
+    /// Air is generated when a block is destroyed and cannot be kept in the inventory.<br />
+    /// <a href="http://minecraft.gamepedia.com/Air">Gamepedia link</a>.
+    /// </summary>
     public class Air : Block
     {
         public Air() : base(BlockType.Air) { }

--- a/Decent.Minecraft.Client/Blocks/Bed.cs
+++ b/Decent.Minecraft.Client/Blocks/Bed.cs
@@ -1,5 +1,11 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// The bed is a multi block structure, allowing the player to sleep in the night.<br />
+    /// Beds are made out of a <see cref="BedFoot">foot</see> and a <see cref="BedFoot">head</see> part.<br />
+    /// Breaking one of the two parts will destroy the other one and drop the bed item.<br />
+    /// <a href="http://minecraft.gamepedia.com/Bed">Gamepedia link</a>.
+    /// </summary>
     public abstract class Bed : Block
     {
         protected Bed(Direction headFacing, bool occupied = false) : base(BlockType.Bed)

--- a/Decent.Minecraft.Client/Blocks/Bed.cs
+++ b/Decent.Minecraft.Client/Blocks/Bed.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// The bed is a multi block structure, allowing the player to sleep in the night.<br />
-    /// Beds are made out of a <see cref="BedFoot">foot</see> and a <see cref="BedFoot">head</see> part.<br />
+    /// Beds are made out of a <see cref="BedFoot">foot</see> and a <see cref="BedHead">head</see> part.<br />
     /// Breaking one of the two parts will destroy the other one and drop the bed item.<br />
     /// <a href="http://minecraft.gamepedia.com/Bed">Gamepedia link</a>.
     /// </summary>

--- a/Decent.Minecraft.Client/Blocks/Bedrock.cs
+++ b/Decent.Minecraft.Client/Blocks/Bedrock.cs
@@ -8,8 +8,6 @@
     /// </summary>
     public class Bedrock : Block
     {
-        public Bedrock() : base(BlockType.Bedrock)
-        {
-        }
+        public Bedrock() : base(BlockType.Bedrock) { }
     }
 }

--- a/Decent.Minecraft.Client/Blocks/Bedrock.cs
+++ b/Decent.Minecraft.Client/Blocks/Bedrock.cs
@@ -1,7 +1,15 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// Bedrock is a indestructible block.<br />
+    /// The bottom of the overworld is made out of Bedrock to prevent falling into death.
+    /// In the nether both the bottom of the world and the top are covered with Bedrock.<br />
+    /// <a href="http://minecraft.gamepedia.com/Bedrock">Gamepedia link</a>.
+    /// </summary>
     public class Bedrock : Block
     {
-        public Bedrock() : base(BlockType.Bedrock) { }
+        public Bedrock() : base(BlockType.Bedrock)
+        {
+        }
     }
 }

--- a/Decent.Minecraft.Client/Blocks/Bone.cs
+++ b/Decent.Minecraft.Client/Blocks/Bone.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Bone_Block">Gamepedia link</a>.
+    /// </summary>
     public class Bone : Block
     {
         public Bone() : base(BlockType.Bone) { }

--- a/Decent.Minecraft.Client/Blocks/Bone.cs
+++ b/Decent.Minecraft.Client/Blocks/Bone.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Bone : Block
+    {
+        public Bone() : base(BlockType.Bone) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Bookshelf.cs
+++ b/Decent.Minecraft.Client/Blocks/Bookshelf.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Bookshelf">Gamepedia link</a>.
+    /// </summary>
     public class Bookshelf : Block
     {
         public Bookshelf() : base(BlockType.Bookshelf) { }

--- a/Decent.Minecraft.Client/Blocks/Bricks.cs
+++ b/Decent.Minecraft.Client/Blocks/Bricks.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Bricks">Gamepedia link</a>.
+    /// </summary>
     public class Bricks : Block
     {
         public Bricks() : base(BlockType.Bricks) { }

--- a/Decent.Minecraft.Client/Blocks/Cactus.cs
+++ b/Decent.Minecraft.Client/Blocks/Cactus.cs
@@ -2,6 +2,9 @@
 
 namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cactus">Gamepedia link</a>.
+    /// </summary>
     public class Cactus : Block
     {
         public Cactus(int age) : base(BlockType.Cactus)

--- a/Decent.Minecraft.Client/Blocks/Chest.cs
+++ b/Decent.Minecraft.Client/Blocks/Chest.cs
@@ -2,6 +2,9 @@
 
 namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Chest">Gamepedia link</a>.
+    /// </summary>
     public class Chest : Block
     {
         public Chest(Direction facing = North) : base(BlockType.Chest)

--- a/Decent.Minecraft.Client/Blocks/Clay.cs
+++ b/Decent.Minecraft.Client/Blocks/Clay.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Clay_(block)">Gamepedia link</a>.
+    /// </summary>
     public class Clay : Block
     {
         public Clay() : base(BlockType.Clay) { }
@@ -7,11 +10,17 @@
 
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Hardened_Clay">Gamepedia link</a>.
+    /// </summary>
     public class HardenedClay : Clay
     {
         public HardenedClay() : base(BlockType.HardenedClay) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Hardened_Clay">Gamepedia link</a>.
+    /// </summary>
     public class StainedClay : HardenedClay, IColoredBlock
     {
         public StainedClay(Color color = Color.White) : base()

--- a/Decent.Minecraft.Client/Blocks/Coal.cs
+++ b/Decent.Minecraft.Client/Blocks/Coal.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Coal">Gamepedia link</a>.
+    /// </summary>
     public class Coal : Block
     {
         public Coal() : base(BlockType.Coal) { }
@@ -11,6 +14,9 @@
         protected bool IsCharred { get; }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Coal_Ore">Gamepedia link</a>.
+    /// </summary>
     public class Charcoal : Coal
     {
         public Charcoal() : base(charred: true) { }

--- a/Decent.Minecraft.Client/Blocks/Coal.cs
+++ b/Decent.Minecraft.Client/Blocks/Coal.cs
@@ -15,10 +15,18 @@
     }
 
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Coal_Ore">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Coal">Gamepedia link</a>.
     /// </summary>
     public class Charcoal : Coal
     {
         public Charcoal() : base(charred: true) { }
+    }
+
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Coal_Ore">Gamepedia link</a>.
+    /// </summary>
+    public class CoalOre : Block
+    {
+        public CoalOre() : base(BlockType.CoalOre) { }
     }
 }

--- a/Decent.Minecraft.Client/Blocks/Coal.cs
+++ b/Decent.Minecraft.Client/Blocks/Coal.cs
@@ -6,20 +6,6 @@
     public class Coal : Block
     {
         public Coal() : base(BlockType.Coal) { }
-        protected Coal(bool charred) : base(BlockType.Coal)
-        {
-            IsCharred = charred;
-        }
-
-        protected bool IsCharred { get; }
-    }
-
-    /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Block_of_Coal">Gamepedia link</a>.
-    /// </summary>
-    public class Charcoal : Coal
-    {
-        public Charcoal() : base(charred: true) { }
     }
 
     /// <summary>

--- a/Decent.Minecraft.Client/Blocks/Cobblestone.cs
+++ b/Decent.Minecraft.Client/Blocks/Cobblestone.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Cobblestone : Block
     {
         public Cobblestone() : base(BlockType.Cobblestone) { }
@@ -11,6 +14,9 @@
         protected bool IsMossy { get; }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Moss_Stone">Gamepedia link</a>.
+    /// </summary>
     public class MossyCobblestone : Cobblestone
     {
         public MossyCobblestone() : base(mossy: true) { }

--- a/Decent.Minecraft.Client/Blocks/Cobweb.cs
+++ b/Decent.Minecraft.Client/Blocks/Cobweb.cs
@@ -1,7 +1,7 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Cobweb">Gamepedia link</a>.
     /// </summary>
     public class Cobweb : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Cobweb.cs
+++ b/Decent.Minecraft.Client/Blocks/Cobweb.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Cobweb : Block
     {
         public Cobweb() : base(BlockType.Cobweb) { }

--- a/Decent.Minecraft.Client/Blocks/CraftingTable.cs
+++ b/Decent.Minecraft.Client/Blocks/CraftingTable.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class CraftingTable : Block
     {
         public CraftingTable() : base (BlockType.CraftingTable) { }

--- a/Decent.Minecraft.Client/Blocks/CraftingTable.cs
+++ b/Decent.Minecraft.Client/Blocks/CraftingTable.cs
@@ -1,7 +1,7 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Crafting_Table">Gamepedia link</a>.
     /// </summary>
     public class CraftingTable : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Diamond.cs
+++ b/Decent.Minecraft.Client/Blocks/Diamond.cs
@@ -1,10 +1,16 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Diamond : Block
     {
         public Diamond() : base(BlockType.Diamond) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class DiamondOre : Block
     {
         public DiamondOre() : base(BlockType.DiamondOre) { }

--- a/Decent.Minecraft.Client/Blocks/Diamond.cs
+++ b/Decent.Minecraft.Client/Blocks/Diamond.cs
@@ -1,7 +1,7 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Diamond">Gamepedia link</a>.
     /// </summary>
     public class Diamond : Block
     {
@@ -9,7 +9,7 @@
     }
 
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Diamond_Ore">Gamepedia link</a>.
     /// </summary>
     public class DiamondOre : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Dirt.cs
+++ b/Decent.Minecraft.Client/Blocks/Dirt.cs
@@ -1,11 +1,20 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Dirt : Block
     {
         public Dirt() : base(BlockType.Dirt) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class CoarseDirt : Dirt { }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Podzol : Dirt { }
 }

--- a/Decent.Minecraft.Client/Blocks/Dirt.cs
+++ b/Decent.Minecraft.Client/Blocks/Dirt.cs
@@ -1,7 +1,7 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Dirt">Gamepedia link</a>.
     /// </summary>
     public class Dirt : Block
     {
@@ -9,12 +9,12 @@
     }
 
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Coarse_Dirt">Gamepedia link</a>.
     /// </summary>
     public class CoarseDirt : Dirt { }
 
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Podzol">Gamepedia link</a>.
     /// </summary>
     public class Podzol : Dirt { }
 }

--- a/Decent.Minecraft.Client/Blocks/Door.cs
+++ b/Decent.Minecraft.Client/Blocks/Door.cs
@@ -1,6 +1,9 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
-    //TODO: make wood species a property
+    /// <summary>
+    /// TODO: make wood species a property
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public abstract class Door : Block
     {
         protected Door(BlockType type) : base(type) { }

--- a/Decent.Minecraft.Client/Blocks/Door.cs
+++ b/Decent.Minecraft.Client/Blocks/Door.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// TODO: make wood species a property
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Door">Gamepedia link</a>.
     /// </summary>
     public abstract class Door : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Emerald.cs
+++ b/Decent.Minecraft.Client/Blocks/Emerald.cs
@@ -1,7 +1,7 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Emerald">Gamepedia link</a>.
     /// </summary>
     public class Emerald : Block
     {
@@ -9,7 +9,7 @@
     }
 
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Emerald_Ore">Gamepedia link</a>.
     /// </summary>
     public class EmeraldOre : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Emerald.cs
+++ b/Decent.Minecraft.Client/Blocks/Emerald.cs
@@ -1,10 +1,16 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Emerald : Block
     {
         public Emerald() : base(BlockType.Emerald) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class EmeraldOre : Block
     {
         public EmeraldOre() : base(BlockType.EmeraldOre) { }

--- a/Decent.Minecraft.Client/Blocks/EndStone.cs
+++ b/Decent.Minecraft.Client/Blocks/EndStone.cs
@@ -1,6 +1,9 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
-	public class EndStone : Block
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
+    public class EndStone : Block
 	{
 		public EndStone() : base(BlockType.EndStone) { }
 	}

--- a/Decent.Minecraft.Client/Blocks/EndStone.cs
+++ b/Decent.Minecraft.Client/Blocks/EndStone.cs
@@ -1,7 +1,7 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/End_Stone">Gamepedia link</a>.
     /// </summary>
     public class EndStone : Block
 	{

--- a/Decent.Minecraft.Client/Blocks/Farmland.cs
+++ b/Decent.Minecraft.Client/Blocks/Farmland.cs
@@ -3,7 +3,7 @@
 namespace Decent.Minecraft.Client.Blocks
 {
     /// <summary>
-    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// <a href="http://minecraft.gamepedia.com/Farmland">Gamepedia link</a>.
     /// </summary>
     public class Farmland : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Farmland.cs
+++ b/Decent.Minecraft.Client/Blocks/Farmland.cs
@@ -2,6 +2,9 @@
 
 namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Cobblestone">Gamepedia link</a>.
+    /// </summary>
     public class Farmland : Block
     {
         public Farmland(int wetness) : base(BlockType.Farmland)

--- a/Decent.Minecraft.Client/Blocks/Fence.cs
+++ b/Decent.Minecraft.Client/Blocks/Fence.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Fence">Gamepedia link</a>.
+    /// </summary>
     public class Fence : Block
     {
         public Fence() : base(BlockType.Fence) { }

--- a/Decent.Minecraft.Client/Blocks/FenceGate.cs
+++ b/Decent.Minecraft.Client/Blocks/FenceGate.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Fence_Gate">Gamepedia link</a>.
+    /// </summary>
     public class FenceGate : Block
     {
         public FenceGate(Direction facing, bool isOpen) : base(BlockType.FenceGate)

--- a/Decent.Minecraft.Client/Blocks/Fire.cs
+++ b/Decent.Minecraft.Client/Blocks/Fire.cs
@@ -2,6 +2,9 @@
 
 namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Fire">Gamepedia link</a>.
+    /// </summary>
     public class Fire : Block
     {
         public Fire(byte intensity) : base(BlockType.Fire)

--- a/Decent.Minecraft.Client/Blocks/Fire.cs
+++ b/Decent.Minecraft.Client/Blocks/Fire.cs
@@ -9,7 +9,7 @@ namespace Decent.Minecraft.Client.Blocks
     {
         public Fire(byte intensity) : base(BlockType.Fire)
         {
-            if (intensity < 0 || intensity > 15)
+            if (intensity > 15)
             {
                 throw new ArgumentException("Fire intensity must be between 0 and 15.", "intensity");
             }

--- a/Decent.Minecraft.Client/Blocks/Fire.cs
+++ b/Decent.Minecraft.Client/Blocks/Fire.cs
@@ -7,15 +7,15 @@ namespace Decent.Minecraft.Client.Blocks
     /// </summary>
     public class Fire : Block
     {
-        public Fire(byte intensity) : base(BlockType.Fire)
+        public Fire(int intensity) : base(BlockType.Fire)
         {
-            if (intensity > 15)
+            if (intensity < 0 || intensity > 15)
             {
                 throw new ArgumentException("Fire intensity must be between 0 and 15.", "intensity");
             }
             Intensity = intensity;
         }
 
-        public byte Intensity { get; }
+        public int Intensity { get; }
     }
 }

--- a/Decent.Minecraft.Client/Blocks/Glowstone.cs
+++ b/Decent.Minecraft.Client/Blocks/Glowstone.cs
@@ -1,6 +1,9 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
-	public class Glowstone : Block
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Glowstone">Gamepedia link</a>.
+    /// </summary>
+    public class Glowstone : Block
 	{
 		public Glowstone() : base(BlockType.Glowstone) { }
 	}

--- a/Decent.Minecraft.Client/Blocks/Gold.cs
+++ b/Decent.Minecraft.Client/Blocks/Gold.cs
@@ -1,10 +1,16 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Gold">Gamepedia link</a>.
+    /// </summary>
     public class Gold : Block
     {
         public Gold() : base(BlockType.Gold) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Gold_Ore">Gamepedia link</a>.
+    /// </summary>
     public class GoldOre : Block
     {
         public GoldOre() : base(BlockType.GoldOre) { }

--- a/Decent.Minecraft.Client/Blocks/Grass.cs
+++ b/Decent.Minecraft.Client/Blocks/Grass.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Grass">Gamepedia link</a>.
+    /// </summary>
     public class Grass : Block
     {
         public Grass() : base(BlockType.Grass) { }

--- a/Decent.Minecraft.Client/Blocks/Hay.cs
+++ b/Decent.Minecraft.Client/Blocks/Hay.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Hay : Block
+    {
+        public Hay() : base(BlockType.Hay) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Hay.cs
+++ b/Decent.Minecraft.Client/Blocks/Hay.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Hay_Bale">Gamepedia link</a>.
+    /// </summary>
     public class Hay : Block
     {
         public Hay() : base(BlockType.Hay) { }

--- a/Decent.Minecraft.Client/Blocks/Iron.cs
+++ b/Decent.Minecraft.Client/Blocks/Iron.cs
@@ -1,10 +1,16 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Iron">Gamepedia link</a>.
+    /// </summary>
     public class Iron : Block
     {
         public Iron() : base(BlockType.Iron) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Iron_Ore">Gamepedia link</a>.
+    /// </summary>
     public class IronOre : Block
     {
         public IronOre() : base(BlockType.IronOre) { }

--- a/Decent.Minecraft.Client/Blocks/IronBars.cs
+++ b/Decent.Minecraft.Client/Blocks/IronBars.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class IronBars : Block
+    {
+        public IronBars() : base(BlockType.IronBars) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/IronBars.cs
+++ b/Decent.Minecraft.Client/Blocks/IronBars.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Iron_Bars">Gamepedia link</a>.
+    /// </summary>
     public class IronBars : Block
     {
         public IronBars() : base(BlockType.IronBars) { }

--- a/Decent.Minecraft.Client/Blocks/JackOLantern.cs
+++ b/Decent.Minecraft.Client/Blocks/JackOLantern.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class JackOLantern : Block
+    {
+        public JackOLantern() : base(BlockType.JackOLantern) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/JackOLantern.cs
+++ b/Decent.Minecraft.Client/Blocks/JackOLantern.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Jack_o%27Lantern">Gamepedia link</a>.
+    /// </summary>
     public class JackOLantern : Block
     {
         public JackOLantern() : base(BlockType.JackOLantern) { }

--- a/Decent.Minecraft.Client/Blocks/Jukebox.cs
+++ b/Decent.Minecraft.Client/Blocks/Jukebox.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Jukebox">Gamepedia link</a>.
+    /// </summary>
     public class Jukebox : Block
     {
         public Jukebox() : base(BlockType.Jukebox) { }

--- a/Decent.Minecraft.Client/Blocks/Jukebox.cs
+++ b/Decent.Minecraft.Client/Blocks/Jukebox.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Jukebox : Block
+    {
+        public Jukebox() : base(BlockType.Jukebox) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Lava.cs
+++ b/Decent.Minecraft.Client/Blocks/Lava.cs
@@ -1,11 +1,17 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Lava">Gamepedia link</a>.
+    /// </summary>
     public class Lava : Block
     {
         public Lava() : base(BlockType.LavaStationary) { }
         protected Lava(BlockType blockType) : base(blockType) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Lava">Gamepedia link</a>.
+    /// </summary>
     public class LavaFlowing : Lava
     {
         public LavaFlowing() : base(BlockType.LavaFlowing) { }

--- a/Decent.Minecraft.Client/Blocks/Leaves.cs
+++ b/Decent.Minecraft.Client/Blocks/Leaves.cs
@@ -1,5 +1,9 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// TODO add the different tree types. @see WoodSpecies + Dark Oak Leave
+    /// <a href="http://minecraft.gamepedia.com/Leaves">Gamepedia link</a>.
+    /// </summary>
     public class Leaves : Block
     {
         public Leaves() : base(BlockType.Leaves) { }

--- a/Decent.Minecraft.Client/Blocks/Leaves.cs
+++ b/Decent.Minecraft.Client/Blocks/Leaves.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Leaves : Block
+    {
+        public Leaves() : base(BlockType.Leaves) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Magma.cs
+++ b/Decent.Minecraft.Client/Blocks/Magma.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Magma_Block">Gamepedia link</a>.
+    /// </summary>
     public class Magma : Block
     {
         public Magma() : base(BlockType.Magma) { }

--- a/Decent.Minecraft.Client/Blocks/Magma.cs
+++ b/Decent.Minecraft.Client/Blocks/Magma.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Magma : Block
+    {
+        public Magma() : base(BlockType.Magma) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Melon.cs
+++ b/Decent.Minecraft.Client/Blocks/Melon.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Melon_(block)">Gamepedia link</a>.
+    /// </summary>
     public class Melon : Block
     {
         public Melon() : base(BlockType.Melon) { }

--- a/Decent.Minecraft.Client/Blocks/Melon.cs
+++ b/Decent.Minecraft.Client/Blocks/Melon.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Melon : Block
+    {
+        public Melon() : base(BlockType.Melon) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/MossStone.cs
+++ b/Decent.Minecraft.Client/Blocks/MossStone.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Moss_Stone">Gamepedia link</a>.
+    /// </summary>
     public class MossStone : Block
     {
         public MossStone() : base(BlockType.MossStone) {}

--- a/Decent.Minecraft.Client/Blocks/NetherWartBlock.cs
+++ b/Decent.Minecraft.Client/Blocks/NetherWartBlock.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class NetherWartBlock : Block
+    {
+        public NetherWartBlock() : base(BlockType.NetherWartBlock) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/NetherWartBlock.cs
+++ b/Decent.Minecraft.Client/Blocks/NetherWartBlock.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Nether_Wart">Gamepedia link</a>.
+    /// </summary>
     public class NetherWartBlock : Block
     {
         public NetherWartBlock() : base(BlockType.NetherWartBlock) { }

--- a/Decent.Minecraft.Client/Blocks/Netherrack.cs
+++ b/Decent.Minecraft.Client/Blocks/Netherrack.cs
@@ -2,21 +2,7 @@
 {
     /// <summary>
     /// This it the Netherrack block found in the Nether world.<br />
-    /// <a href="http://minecraft.gamepedia.com/Netherrack">Wikipedia link</a>.
-    /// <list type="table">
-    ///   <item>
-    ///     <term>Block</term>
-    ///     <description>Netherrack</description>
-    ///   </item>
-    ///   <item>
-    ///     <term>Hardness</term>
-    ///     <description>0.4</description>
-    ///   </item>
-    ///   <item>
-    ///     <term>Tool</term>
-    ///     <description>Pickaxe</description>
-    ///   </item>
-    /// </list>
+    /// <a href="http://minecraft.gamepedia.com/Netherrack">Gamepedia link</a>.
     /// </summary>
     public class Netherrack : Block
     {

--- a/Decent.Minecraft.Client/Blocks/Netherrack.cs
+++ b/Decent.Minecraft.Client/Blocks/Netherrack.cs
@@ -1,5 +1,23 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// This it the Netherrack block found in the Nether world.<br />
+    /// <a href="http://minecraft.gamepedia.com/Netherrack">Wikipedia link</a>.
+    /// <list type="table">
+    ///   <item>
+    ///     <term>Block</term>
+    ///     <description>Netherrack</description>
+    ///   </item>
+    ///   <item>
+    ///     <term>Hardness</term>
+    ///     <description>0.4</description>
+    ///   </item>
+    ///   <item>
+    ///     <term>Tool</term>
+    ///     <description>Pickaxe</description>
+    ///   </item>
+    /// </list>
+    /// </summary>
     public class Netherrack : Block
     {
         public Netherrack() : base(BlockType.Netherrack) { }

--- a/Decent.Minecraft.Client/Blocks/Netherrack.cs
+++ b/Decent.Minecraft.Client/Blocks/Netherrack.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Netherrack : Block
+    {
+        public Netherrack() : base(BlockType.Netherrack) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Obsidian.cs
+++ b/Decent.Minecraft.Client/Blocks/Obsidian.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Obsidian">Gamepedia link</a>.
+    /// </summary>
     public class Obsidian : Block
     {
         public Obsidian() : base(BlockType.Obsidian) { }

--- a/Decent.Minecraft.Client/Blocks/Pumpkin.cs
+++ b/Decent.Minecraft.Client/Blocks/Pumpkin.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class Pumpkin : Block
+    {
+        public Pumpkin() : base(BlockType.Pumpkin) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Pumpkin.cs
+++ b/Decent.Minecraft.Client/Blocks/Pumpkin.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Pumpkin">Gamepedia link</a>.
+    /// </summary>
     public class Pumpkin : Block
     {
         public Pumpkin() : base(BlockType.Pumpkin) { }

--- a/Decent.Minecraft.Client/Blocks/Quartz.cs
+++ b/Decent.Minecraft.Client/Blocks/Quartz.cs
@@ -1,0 +1,19 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Nether_Quartz_Ore">Gamepedia link</a>.
+    /// </summary>
+    public class QuartzOre : Block
+    {
+        public QuartzOre() : base(BlockType.QuartzOre) { }
+    }
+
+    /// <summary>
+    /// TODO add Chiseled Quartz Block and the Quartz Pillar
+    /// <a href="http://minecraft.gamepedia.com/Block_of_Quartz">Gamepedia link</a>.
+    /// </summary>
+    public class Quartz : Block
+    {
+        public Quartz() : base(BlockType.Quartz) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/QuartzOre.cs
+++ b/Decent.Minecraft.Client/Blocks/QuartzOre.cs
@@ -1,7 +1,0 @@
-﻿namespace Decent.Minecraft.Client.Blocks
-{
-    public class QuartzOre : Block
-    {
-        public QuartzOre() : base(BlockType.QuartzOre) { }
-    }
-}

--- a/Decent.Minecraft.Client/Blocks/QuartzOre.cs
+++ b/Decent.Minecraft.Client/Blocks/QuartzOre.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class QuartzOre : Block
+    {
+        public QuartzOre() : base(BlockType.QuartzOre) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/Snow.cs
+++ b/Decent.Minecraft.Client/Blocks/Snow.cs
@@ -2,6 +2,9 @@
 
 namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Snow">Gamepedia link</a>.
+    /// </summary>
     public class Snow : Block
     {
         public Snow(int thickness = 8) : base(BlockType.SnowLayer)

--- a/Decent.Minecraft.Client/Blocks/SoulSand.cs
+++ b/Decent.Minecraft.Client/Blocks/SoulSand.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class SoulSand : Block
+    {
+        public SoulSand() : base(BlockType.SoulSand) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/SoulSand.cs
+++ b/Decent.Minecraft.Client/Blocks/SoulSand.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Soul_Sand">Gamepedia link</a>.
+    /// </summary>
     public class SoulSand : Block
     {
         public SoulSand() : base(BlockType.SoulSand) { }

--- a/Decent.Minecraft.Client/Blocks/Stone.cs
+++ b/Decent.Minecraft.Client/Blocks/Stone.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Stone">Gamepedia link</a>.
+    /// </summary>
     public class Stone : Block
     {
         public Stone(Mineral mineral = Mineral.Stone) : base(BlockType.Stone)

--- a/Decent.Minecraft.Client/Blocks/StoneBricks.cs
+++ b/Decent.Minecraft.Client/Blocks/StoneBricks.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Stone_Bricks">Gamepedia link</a>.
+    /// </summary>
     public class StoneBricks : Block
     {
         public StoneBricks() : this(StoneQuality.Normal) { }
@@ -20,16 +23,25 @@
         }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Stone_Bricks">Gamepedia link</a>.
+    /// </summary>
     public class MossyStoneBricks : StoneBricks
     {
         public MossyStoneBricks() : base(StoneQuality.Mossy) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Stone_Bricks">Gamepedia link</a>.
+    /// </summary>
     public class CrackedStoneBricks : StoneBricks
     {
         public CrackedStoneBricks() : base(StoneQuality.Cracked) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Stone_Bricks">Gamepedia link</a>.
+    /// </summary>
     public class ChiseledStoneBricks : StoneBricks
     {
         public ChiseledStoneBricks() : base(StoneQuality.Chiseled) { }

--- a/Decent.Minecraft.Client/Blocks/TNT.cs
+++ b/Decent.Minecraft.Client/Blocks/TNT.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class TNT : Block
+    {
+        public TNT() : base(BlockType.TNT) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/TNT.cs
+++ b/Decent.Minecraft.Client/Blocks/TNT.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/TNT">Gamepedia link</a>.
+    /// </summary>
     public class TNT : Block
     {
         public TNT() : base(BlockType.TNT) { }

--- a/Decent.Minecraft.Client/Blocks/Water.cs
+++ b/Decent.Minecraft.Client/Blocks/Water.cs
@@ -1,11 +1,17 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Water">Gamepedia link</a>.
+    /// </summary>
     public class Water : Block
     {
         public Water() : base(BlockType.WaterStationary) { }
         protected Water(BlockType blockType) : base(blockType) { }
     }
 
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Water">Gamepedia link</a>.
+    /// </summary>
     public class WaterFlowing : Water
     {
         public WaterFlowing() : base(BlockType.WaterFlowing) { }

--- a/Decent.Minecraft.Client/Blocks/WaterLily.cs
+++ b/Decent.Minecraft.Client/Blocks/WaterLily.cs
@@ -1,0 +1,7 @@
+﻿namespace Decent.Minecraft.Client.Blocks
+{
+    public class WaterLily : Block
+    {
+        public WaterLily() : base(BlockType.WaterLily) { }
+    }
+}

--- a/Decent.Minecraft.Client/Blocks/WaterLily.cs
+++ b/Decent.Minecraft.Client/Blocks/WaterLily.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Lily_Pad">Gamepedia link</a>.
+    /// </summary>
     public class WaterLily : Block
     {
         public WaterLily() : base(BlockType.WaterLily) { }

--- a/Decent.Minecraft.Client/Blocks/Wood.cs
+++ b/Decent.Minecraft.Client/Blocks/Wood.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Wood">Gamepedia link</a>.
+    /// </summary>
     public class Wood : Block
     {
         private Wood(): base(BlockType.Wood) { }

--- a/Decent.Minecraft.Client/Blocks/Wool.cs
+++ b/Decent.Minecraft.Client/Blocks/Wool.cs
@@ -1,5 +1,8 @@
 ﻿namespace Decent.Minecraft.Client.Blocks
 {
+    /// <summary>
+    /// <a href="http://minecraft.gamepedia.com/Wool">Gamepedia link</a>.
+    /// </summary>
     public class Wool : Block, IColoredBlock
     {
         public Wool(Color color = Color.White) : base(BlockType.Wool)

--- a/Decent.Minecraft.Client/JavaBlock.cs
+++ b/Decent.Minecraft.Client/JavaBlock.cs
@@ -39,6 +39,7 @@ namespace Decent.Minecraft.Client
                 }
             };
             _ctors[(int)BlockType.Bedrock] = d => new Bedrock();
+            _ctors[(int)BlockType.Bone] = d => new Bone();
             _ctors[(int)BlockType.Bookshelf] = d => new Bookshelf();
             _ctors[(int)BlockType.Bricks] = d => new Bricks();
             _ctors[(int)BlockType.Cactus] = d => new Cactus(d);
@@ -90,12 +91,23 @@ namespace Decent.Minecraft.Client
             _ctors[(int)BlockType.Gold] = d => new Gold();
             _ctors[(int)BlockType.GoldOre] = d => new GoldOre();
             _ctors[(int)BlockType.Grass] = d => new Grass();
+            _ctors[(int)BlockType.Hay] = d => new Hay();
             _ctors[(int)BlockType.Iron] = d => new Iron();
+            _ctors[(int)BlockType.IronBars] = d => new IronBars();
             _ctors[(int)BlockType.IronOre] = d => new IronOre();
+            _ctors[(int)BlockType.Jukebox] = d => new Jukebox();
+            _ctors[(int)BlockType.JackOLantern] = d => new JackOLantern();
             _ctors[(int)BlockType.LavaFlowing] = d => new LavaFlowing();
             _ctors[(int)BlockType.LavaStationary] = d => new Lava();
+            _ctors[(int)BlockType.Leaves] = d => new Leaves();
+            _ctors[(int)BlockType.Magma] = d => new Magma();
             _ctors[(int)BlockType.MossStone] = d => new MossStone();
+            _ctors[(int)BlockType.Melon] = d => new Melon();
+            _ctors[(int)BlockType.Netherrack] = d => new Netherrack();
+            _ctors[(int)BlockType.NetherWartBlock] = d => new NetherWartBlock();
             _ctors[(int)BlockType.Obsidian] = d => new Obsidian();
+            _ctors[(int)BlockType.Pumpkin] = d => new Pumpkin();
+            _ctors[(int)BlockType.QuartzOre] = d => new QuartzOre();
             _ctors[(int)BlockType.Snow] = d => new Snow(8);
             _ctors[(int)BlockType.SnowLayer] = d => new Snow(d);
             _ctors[(int)BlockType.StainedClay] = d => new StainedClay((Color)d);
@@ -105,6 +117,9 @@ namespace Decent.Minecraft.Client
                 d == 1 ? new MossyStoneBricks() :
                 d == 2 ? new CrackedStoneBricks() :
                 (Block)new ChiseledStoneBricks();
+            _ctors[(int)BlockType.SoulSand] = d => new SoulSand();
+            _ctors[(int)BlockType.TNT] = d => new TNT();
+            _ctors[(int)BlockType.WaterLily] = d => new WaterLily();
             _ctors[(int)BlockType.WaterStationary] = d => new Water();
             _ctors[(int)BlockType.Wood] = d => new Wood((WoodSpecies)(d & 0x3), (Orientation)(d & 0xC));
             _ctors[(int)BlockType.Wool] = d => new Wool((Color)d);


### PR DESCRIPTION
This PR adds the following new blocks:

- Bone
- Jukebox
- IronBars
- SoulSand
- Netherrack
- Hay
- JackOLantern 
- Leaves
- Magma
- Melon
- Pumpkin
- QuartzOre
- Quartz
- TNT
- WaterLily

In addition it adds summaries to all (common) block types. I wasn't sure how to handle the different door types, so I'm open for suggestions (looking forwards to trapdoors and other multiblocks)

An unnecessary check got removed and the .idea-folder from the IDE Raider got it's place in the .ignore file.